### PR TITLE
Add AreaHeal as valid EffectAction.

### DIFF
--- a/src/Enum/ProtoActionName.cs
+++ b/src/Enum/ProtoActionName.cs
@@ -32,6 +32,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Enum
         [XmlEnum("Repair")] [EnumMember(Value = "Repair")] Repair = 17,
         [XmlEnum("Sacrifice")] [EnumMember(Value = "Sacrifice")] Sacrifice = 18,
         [XmlEnum("SelfHeal")] [EnumMember(Value = "SelfHeal")] SelfHeal = 19,
-        [XmlEnum("Trade")] [EnumMember(Value = "Trade")] Trade = 20
+        [XmlEnum("Trade")] [EnumMember(Value = "Trade")] Trade = 20,
+        [XmlEnum("AreaHeal")] [EnumMember(Value = "AreaHeal")] AreaHeal = 21
     }
 }


### PR DESCRIPTION
This is needed for the Roman Clinicus unit to function properly. It has no effect on the user side of things. Nothing changes in the UI.

Because of how the Clinicus Upgrade works, there needs to be 2 different ProtoActions for the unit.

![image](https://user-images.githubusercontent.com/9396067/82100891-36a8c800-9720-11ea-9136-09cb4c36c232.png)

In order for this to work, this effect needs to be added as a valid EffectAction type so that it can affect the Clinicus after the upgrade has been researched, otherwise gear won't affect them once the upgrade is researched.


``<Effect action="Heal" amount="0.00" relativity="Absolute" subtype="ActionEnable" type="Data">
				<Target type="ProtoUnit">Ro_Spc_Clinicus</Target>
			</Effect>
			<Effect action="AreaHeal" amount="1.00" relativity="Absolute" subtype="ActionEnable" type="Data">
				<Target type="ProtoUnit">Ro_Spc_Clinicus</Target>
			</Effect>``


Then the healing staffs inside traits.xml need to be updated with this kind of change:


``<effect type="Data" bonus="true" action="Heal" amount="1.0122" scaling="0.002" subtype="WorkRate" visible="true" unittype="LogicalTypeHealed" relativity="Percent">
				<target type="Player"/>
			</effect>
			<!-- ADDED FOR ROMAN CLINICUS -->
			<effect type="Data" bonus="true" action="AreaHeal" amount="1.0122" scaling="0.002" subtype="WorkRate" visible="true" unittype="LogicalTypeHealed" relativity="Percent">
				<target type="Player"/>
			</effect>``


Which will not change the tooltip for Staffs in any way at all.

![image](https://user-images.githubusercontent.com/9396067/82101077-ae76f280-9720-11ea-8470-7867b4b12bce.png)


