### PR TITLE
Updated logic for Effect Traits

### DIFF
--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -391,6 +391,8 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                 {
                     case RelativityEnum.Absolute:
                         return result + 1;
+                    case RelativityEnum.Assign:
+                        return result + 1;
                     default:
                         return result;
                 }
@@ -408,6 +410,8 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             switch (effect.Relativity)
             {
                 case RelativityEnum.Absolute:
+                    return result + 1;
+                case RelativityEnum.Assign:
                     return result + 1;
                 default:
                     return result;

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -386,7 +386,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             var result = effect.Scaling * lvl + effect.Amount;
             
             //if (finalSeed <= 0 && (result <= 1 || result > 4))
-            if (finalSeed <= 0 && effect.Relativity = "Absolute")
+            if (finalSeed <= 0 && effect.Relativity = RelativityEnum.Absolute)
                 return result + 1;
 
             if (finalSeed <= 0)
@@ -398,7 +398,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                 result = 1.0 - result + 1.0;
 
             //Ignore Armor and maybe if regen becomes a stat that 
-            if (effect.Relativity = "Absolute")
+            if (effect.Relativity = RelativityEnum.Absolute)
                 return result + 1;
             
             return result;

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -366,6 +366,8 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             string language = "English")
         {
             var modifiers = item.Effects.GetEffectsModifier(lvl, seed);
+            //would be better if we can split this differently but it is fine enough like this
+            /*
             switch (effect.Relativity)
             {
                 case RelativityEnum.Absolute:
@@ -389,6 +391,10 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                         (current, modifier) => current +
                                             $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value - 1.0) * 100, 2, MidpointRounding.AwayFromZero)}%\r\n");;
             }
+            */
+            return modifiers.Aggregate(string.Empty,
+                (current, modifier) => current +
+                                    $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value - 1.0) * 100, 2, MidpointRounding.AwayFromZero)}%\r\n");;
         }
 
         public static IEnumerable<KeyValuePair<EconTraitXmlEffect, double>> GetEffectsModifier(
@@ -434,7 +440,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                 result = 1.0 - result + 1.0;
 
             //Ignore Armor and maybe if regen becomes a stat that 
-            /*switch (effect.Relativity)
+            switch (effect.Relativity)
             {
                 case RelativityEnum.Absolute:
                     return result + 1;
@@ -442,7 +448,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     return result + 1;
                 default:
                     return result;
-            }*/
+            }
             return result;
         }
     }

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -52,36 +52,27 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.CarryCapacity:
                     {
+                        //return languages["stringtablex"][language][64947].Text + languages["stringtablex"][language][66918].Text;
                         // ReSharper disable once SwitchStatementMissingSomeCases
                         switch (effect.UnitType)
                         {
-                            case EffectUnitTypeEnum.AbstractFarm:
+                            //ResourceTypeEnum is taken from Resource.cs
+                            //Will this work as it is?
+                            case ResourceTypeEnum.Food:
                                 return
-                                    $"{languages["stringtablex"][language][65869].Text}:";
-                            case EffectUnitTypeEnum.AbstractFish:
+                                    languages["stringtablex"][language][18900].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                            case ResourceTypeEnum.Gold:
                                 return
-                                    $"{languages["stringtablex"][language][65870].Text}:";
-                            case EffectUnitTypeEnum.AbstractFruit:
+                                    languages["stringtablex"][language][18129].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                            case ResourceTypeEnum.Stone:
                                 return
-                                    $"{languages["stringtablex"][language][65866].Text}:";
-                            case EffectUnitTypeEnum.Fish:
+                                    languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                            case ResourceTypeEnum.stone:
                                 return
-                                    $"{languages["stringtablex"][language][65870].Text}:";
-                            case EffectUnitTypeEnum.Gold:
+                                    languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                            case ResourceTypeEnum.Tree:
                                 return
-                                    $"{languages["stringtablex"][language][65872].Text}:";
-                            case EffectUnitTypeEnum.Herdable:
-                                return
-                                    $"{languages["stringtablex"][language][65867].Text}:";
-                            case EffectUnitTypeEnum.Huntable:
-                                return
-                                    $"{languages["stringtablex"][language][65868].Text}:";
-                            case EffectUnitTypeEnum.Stone:
-                                return
-                                    $"{languages["stringtablex"][language][65873].Text}:";
-                            case EffectUnitTypeEnum.Tree:
-                                return
-                                    $"{languages["stringtablex"][language][65871].Text}:";
+                                    languages["stringtablex"][language][18899].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
                             default:
                                 throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
                         }
@@ -115,7 +106,20 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.HitPercent:
                     {
-                        return languages["stringtablex"][language][55093].Text.Replace(" +%1.0f", ":");
+                        switch (effect.UnitType)
+                        {
+                            //Should show what unit receives the Critical Chance
+                            case EffectActionTypeEnum.MeleeAttack:
+                                return
+                                    languages["stringtablex"][language][58251].Text + " " + languages["stringtablex"][language][55093].Text.Replace(" +%1.0f", ":");;
+                            case EffectActionTypeEnum.RangedAttack:
+                                return
+                                    languages["stringtablex"][language][58250].Text + " " + languages["stringtablex"][language][55093].Text.Replace(" +%1.0f", ":");;
+                            default:
+                                return 
+                                    languages["stringtablex"][language][55093].Text.Replace(" +%1.0f", ":");;
+                        }
+                        //return languages["stringtablex"][language][55093].Text.Replace(" +%1.0f", ":");;
                     }
                 case EffectSubTypeEnum.Hitpoints:
                     {
@@ -127,7 +131,27 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.MaximumRange:
                     {
-                        return languages["stringtablex"][language][58203].Text;
+                        switch (effect.UnitType)
+                        {
+                            //Should show what type of Max range bonus is applied
+                            case EffectActionTypeEnum.RsangedAttack:
+                                return
+                                    languages["stringtablex"][language][58250].Text + " " + languages["stringtablex"][language][58203].Text;
+                            case EffectActionTypeEnum.RangedAttack2:
+                                return
+                                    languages["stringtablex"][language][58250].Text + "2 " + languages["stringtablex"][language][58203].Text;
+                            //This is either burning pitch or is now for Set priest for AOE convert... there is no string showing other
+                            case EffectActionTypeEnum.BurningAttack:
+                                return
+                                    languages["stringtablex"][language][58203].Text;
+                            case EffectActionTypeEnum.Convert:
+                                return
+                                    languages["stringtablex"][language][65459].Text + " " + languages["stringtablex"][language][58203].Text;
+                            default:
+                                return 
+                                    languages["stringtablex"][language][58203].Text;
+                        }
+                        //return languages["stringtablex"][language][58203].Text;
                     }
                 case EffectSubTypeEnum.MaximumVelocity:
                     {
@@ -145,9 +169,79 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     {
                         return languages["stringtablex"][language][57583].Text;
                     }
+                case EffectSubTypeEnum.ArmorVulnerability:
+                    {
+                        return languages["stringtablex"][language][300021].Text;
+                    }
                 case EffectSubTypeEnum.WorkRate:
                     {
-                        return languages["stringtablex"][language][55094].Text.Replace(" +%1.1f", string.Empty);
+                        switch (effect.UnitType)
+                        {
+                            case EffectUnitTypeEnum.AbstractFruit:
+                                return
+                                    $"{languages["stringtablex"][language][65866].Text}:";
+                            case EffectUnitTypeEnum.AbstractFish:
+                                return
+                                    $"{languages["stringtablex"][language][65870].Text}:";
+                            case EffectUnitTypeEnum.AbstractFruit:
+                                return
+                                    $"{languages["stringtablex"][language][65866].Text}:";
+                            case EffectUnitTypeEnum.Fish:
+                                return
+                                    $"{languages["stringtablex"][language][65870].Text}:";
+                            case EffectUnitTypeEnum.Gold:
+                                return
+                                    $"{languages["stringtablex"][language][65872].Text}:";
+                            case EffectUnitTypeEnum.Herdable:
+                                return
+                                    $"{languages["stringtablex"][language][65867].Text}:";
+                            case EffectUnitTypeEnum.Huntable:
+                                return
+                                    $"{languages["stringtablex"][language][65868].Text}:";
+                            case EffectUnitTypeEnum.Stone:
+                                return
+                                    $"{languages["stringtablex"][language][65873].Text}:";
+                            case EffectUnitTypeEnum.Tree:
+                                return
+                                    $"{languages["stringtablex"][language][65871].Text}:";
+                            case EffectUnitTypeEnum.Building:
+                                return
+                                    $"{languages["stringtablex"][language][55353].Text}:";
+                            case EffectUnitTypeEnum.LogicalTypeHealed:
+                                return
+                                    $"{languages["stringtablex"][language][55354].Text}:";
+                            case EffectUnitTypeEnum.AbstractTownCenter:
+                                return
+                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][54006].Text;
+                            case EffectUnitTypeEnum.AbstractDock:
+                                return
+                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][49782].Text;
+                            case EffectUnitTypeEnum.Dropsite:
+                                return
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56286].Text;
+                            case EffectUnitTypeEnum.ActionTrain:
+                                return
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56288].Text;
+                            case EffectUnitTypeEnum.ActionBuild:
+                                return
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56287].Text;
+                            case EffectUnitTypeEnum.SelfHeal:
+                                return
+                                    $"{languages["stringtablex"][language][57824].Text}:";
+                            case EffectUnitTypeEnum.ConvertableCavalry:
+                                return
+                                    languages["stringtablex"][language][38214].Text + " " + languages["stringtablex"][language][65459].Text;
+                            case EffectUnitTypeEnum.ConvertableSiege:
+                                return
+                                    languages["stringtablex"][language][42026].Text + " " + languages["stringtablex"][language][65459].Text;
+                            case EffectUnitTypeEnum.ConvertableInfantry:
+                                return
+                                    languages["stringtablex"][language][42167].Text + " " + languages["stringtablex"][language][65459].Text;
+                            default:
+                                //Instead of throw excemption, I put a default text.
+                                return languages["stringtablex"][language][66811].Text.Replace(" +%1.1f", string.Empty);
+                                //throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
+                        }
                     }
                 default:
                     {
@@ -299,6 +393,13 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             var finalSeed = seed > 0 && seedoffset < 4 ? (seed & (255 << (8 * seedoffset))) >> (8 * seedoffset) : 0;
 
             var result = effect.Scaling * lvl + effect.Amount;
+            
+            //1 or below means that it is not a multiplier and over 4 means it is talking about regen... better would be to identify the enum from above... you decide
+            //1 is an action, below 1 is a additive (e.g. Ignore Armor)
+            //above 4 is not normal for a percentage multiplier. cos that would be 400% times the gear. This is the Regen bonus for example Zahhak and that is also a static number.
+            if (finalSeed <= 0 && (result <= 1 || result > 4))
+                return result + 1;
+
             if (finalSeed <= 0)
                 return result;
 
@@ -306,7 +407,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             result = modifier * (result - 1.0) + 1.0;
             if (effect.IsBonus && result < 1)
                 result = 1.0 - result + 1.0;
-
+            
             return result;
         }
     }

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -54,7 +54,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     {
                         //return languages["stringtablex"][language][64947].Text + languages["stringtablex"][language][66918].Text;
                         // ReSharper disable once SwitchStatementMissingSomeCases
-                        switch (effect.UnitType)
+                        switch (effect.Resource)
                         {
                             //ResourceTypeEnum is taken from Resource.cs
                             //Will this work as it is?
@@ -106,7 +106,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.HitPercent:
                     {
-                        switch (effect.UnitType)
+                        switch (effect.Action)
                         {
                             //Should show what unit receives the Critical Chance
                             case EffectActionTypeEnum.MeleeAttack:
@@ -131,7 +131,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.MaximumRange:
                     {
-                        switch (effect.UnitType)
+                        switch (effect.Action)
                         {
                             //Should show what type of Max range bonus is applied
                             case EffectActionTypeEnum.RsangedAttack:

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -386,22 +386,32 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             var result = effect.Scaling * lvl + effect.Amount;
             
             //if (finalSeed <= 0 && (result <= 1 || result > 4))
-            if (finalSeed <= 0 && effect.Relativity = RelativityEnum.Absolute)
-                return result + 1;
-
+            if (finalSeed <= 0) {
+                switch (effect.Relativity)
+                {
+                    case RelativityEnum.Absolute:
+                        return result + 1;
+                    default:
+                        return result;
+                }
+            }                
+/*
             if (finalSeed <= 0)
                 return result;
-
+*/
             var modifier = ((int)(finalSeed * 0.078431375) - 10.0) * 0.004999999888241291 + 1.0;
             result = modifier * (result - 1.0) + 1.0;
             if (effect.IsBonus && result < 1)
                 result = 1.0 - result + 1.0;
 
             //Ignore Armor and maybe if regen becomes a stat that 
-            if (effect.Relativity = RelativityEnum.Absolute)
-                return result + 1;
-            
-            return result;
+            switch (effect.Relativity)
+            {
+                case RelativityEnum.Absolute:
+                    return result + 1;
+                default:
+                    return result;
+            }
         }
     }
 }

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -385,10 +385,8 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
 
             var result = effect.Scaling * lvl + effect.Amount;
             
-            //1 or below means that it is not a multiplier and over 4 means it is talking about regen... better would be to identify the enum from above... you decide
-            //1 is an action, below 1 is a additive (e.g. Ignore Armor)
-            //above 4 is not normal for a percentage multiplier. cos that would be 400% times the gear. This is the Regen bonus for example Zahhak and that is also a static number.
-            if (finalSeed <= 0 && (result <= 1 || result > 4))
+            //if (finalSeed <= 0 && (result <= 1 || result > 4))
+            if (finalSeed <= 0 && effect.Relativity = "Absolute")
                 return result + 1;
 
             if (finalSeed <= 0)
@@ -398,6 +396,10 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             result = modifier * (result - 1.0) + 1.0;
             if (effect.IsBonus && result < 1)
                 result = 1.0 - result + 1.0;
+
+            //Ignore Armor and maybe if regen becomes a stat that 
+            if (effect.Relativity = "Absolute")
+                return result + 1;
             
             return result;
         }

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -60,18 +60,19 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                             //Will this work as it is?
                             case ResourceTypeEnum.Food:
                                 return
-                                    languages["stringtablex"][language][18900].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                                    languages["stringtablex"][language][18900].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text + ":";
                             case ResourceTypeEnum.Gold:
                                 return
-                                    languages["stringtablex"][language][18129].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                                    languages["stringtablex"][language][18129].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text + ":";
                             case ResourceTypeEnum.Stone:
                                 return
-                                    languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                                    languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text + ":";
                             case ResourceTypeEnum.Wood:
                                 return
-                                    languages["stringtablex"][language][18899].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
+                                    languages["stringtablex"][language][18899].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text + ":";
                             default:
-                                throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
+                                //throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
+                                return languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text + ":";
                         }
                     }
                 case EffectSubTypeEnum.ConvertResist:
@@ -202,35 +203,41 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                                 return
                                     $"{languages["stringtablex"][language][55353].Text}:";
                             case EffectUnitTypeEnum.LogicalTypeHealed:
-                                return
-                                    $"{languages["stringtablex"][language][55354].Text}:";
+                                switch (effect.Action)
+                                {
+                                    case EffectActionTypeEnum.SelfHeal:
+                                        return
+                                            $"{languages["stringtablex"][language][300031].Text}:";
+                                    default: return
+                                        $"{languages["stringtablex"][language][55354].Text}:";
+                                }
                             case EffectUnitTypeEnum.AbstractTownCenter:
                                 return
-                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][54006].Text;
+                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][54006].Text + ":";
                             case EffectUnitTypeEnum.AbstractDock:
                                 return
-                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][49782].Text;
+                                    languages["stringtablex"][language][55355].Text + " " + languages["stringtablex"][language][49782].Text + ":";
                             case EffectUnitTypeEnum.Dropsite:
                                 return
-                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56286].Text;
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56286].Text + ":";
                             case EffectUnitTypeEnum.ActionTrain:
                                 return
-                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56288].Text;
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56288].Text + ":";
                             case EffectUnitTypeEnum.ActionBuild:
                                 return
-                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56287].Text;
+                                    languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56287].Text + ":";
                             case EffectUnitTypeEnum.ConvertableCavalry:
                                 return
-                                    languages["stringtablex"][language][38214].Text + " " + languages["stringtablex"][language][65459].Text;
+                                    languages["stringtablex"][language][38214].Text + " " + languages["stringtablex"][language][65459].Text + ":";
                             case EffectUnitTypeEnum.ConvertableSiege:
                                 return
-                                    languages["stringtablex"][language][42026].Text + " " + languages["stringtablex"][language][65459].Text;
+                                    languages["stringtablex"][language][42026].Text + " " + languages["stringtablex"][language][65459].Text + ":";
                             case EffectUnitTypeEnum.ConvertableInfantry:
                                 return
-                                    languages["stringtablex"][language][42167].Text + " " + languages["stringtablex"][language][65459].Text;
+                                    languages["stringtablex"][language][42167].Text + " " + languages["stringtablex"][language][65459].Text + ":";
                             default:
                                 //Instead of throw excemption, I put a default text.
-                                return languages["stringtablex"][language][66811].Text.Replace(" +%1.1f", string.Empty);
+                                return languages["stringtablex"][language][66811].Text.Replace(" +%1.1f", string.Empty) + ":";
                                 //throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
                         }
                     }
@@ -359,9 +366,29 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
             string language = "English")
         {
             var modifiers = item.Effects.GetEffectsModifier(lvl, seed);
-            return modifiers.Aggregate(string.Empty,
-                (current, modifier) => current +
-                                       $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value - 1.0) * 100, 2, MidpointRounding.AwayFromZero)}%\r\n");
+            switch (effect.Relativity)
+            {
+                case RelativityEnum.Absolute:
+                    switch (effect.Action)
+                    {
+                        case EffectActionTypeEnum.SelfHeal:
+                            return modifiers.Aggregate(string.Empty,
+                                (current, modifier) => current +
+                                                    $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value), 2, MidpointRounding.AwayFromZero)}/s\r\n");;
+                        default:
+                            return modifiers.Aggregate(string.Empty,
+                                (current, modifier) => current +
+                                                    $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value) * 100, 2, MidpointRounding.AwayFromZero)}%\r\n");;
+                    }
+                case RelativityEnum.Assign:
+                    return modifiers.Aggregate(string.Empty,
+                        (current, modifier) => current +
+                                            $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value), 2, MidpointRounding.AwayFromZero)}\r\n");;
+                default:
+                    return modifiers.Aggregate(string.Empty,
+                        (current, modifier) => current +
+                                            $"{GetDisplayNameLocalized(modifier.Key, languages, language)} {Math.Round((modifier.Value - 1.0) * 100, 2, MidpointRounding.AwayFromZero)}%\r\n");;
+            }
         }
 
         public static IEnumerable<KeyValuePair<EconTraitXmlEffect, double>> GetEffectsModifier(
@@ -407,7 +434,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                 result = 1.0 - result + 1.0;
 
             //Ignore Armor and maybe if regen becomes a stat that 
-            switch (effect.Relativity)
+            /*switch (effect.Relativity)
             {
                 case RelativityEnum.Absolute:
                     return result + 1;
@@ -415,7 +442,8 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     return result + 1;
                 default:
                     return result;
-            }
+            }*/
+            return result;
         }
     }
 }

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -137,7 +137,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                                     languages["stringtablex"][language][58250].Text + " " + languages["stringtablex"][language][58203].Text;
                             case EffectActionTypeEnum.RangedAttack2:
                                 return
-                                    languages["stringtablex"][language][58250].Text + "2 " + languages["stringtablex"][language][58203].Text;
+                                    languages["stringtablex"][language][58250].Text + " " + languages["stringtablex"][language][58203].Text;
                             //This is either burning pitch or is now for Set priest for AOE convert... there is no string showing other
                             case EffectActionTypeEnum.BurningAttack:
                                 return

--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -67,10 +67,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                             case ResourceTypeEnum.Stone:
                                 return
                                     languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
-                            case ResourceTypeEnum.stone:
-                                return
-                                    languages["stringtablex"][language][28529].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
-                            case ResourceTypeEnum.Tree:
+                            case ResourceTypeEnum.Wood:
                                 return
                                     languages["stringtablex"][language][18899].Text + " " + languages["stringtablex"][language][64947].Text + " " + languages["stringtablex"][language][66918].Text;
                             default:
@@ -134,7 +131,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                         switch (effect.Action)
                         {
                             //Should show what type of Max range bonus is applied
-                            case EffectActionTypeEnum.RsangedAttack:
+                            case EffectActionTypeEnum.RangedAttack:
                                 return
                                     languages["stringtablex"][language][58250].Text + " " + languages["stringtablex"][language][58203].Text;
                             case EffectActionTypeEnum.RangedAttack2:
@@ -183,9 +180,6 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                             case EffectUnitTypeEnum.AbstractFish:
                                 return
                                     $"{languages["stringtablex"][language][65870].Text}:";
-                            case EffectUnitTypeEnum.AbstractFruit:
-                                return
-                                    $"{languages["stringtablex"][language][65866].Text}:";
                             case EffectUnitTypeEnum.Fish:
                                 return
                                     $"{languages["stringtablex"][language][65870].Text}:";
@@ -225,9 +219,6 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                             case EffectUnitTypeEnum.ActionBuild:
                                 return
                                     languages["stringtablex"][language][56285].Text + " " + languages["stringtablex"][language][56287].Text;
-                            case EffectUnitTypeEnum.SelfHeal:
-                                return
-                                    $"{languages["stringtablex"][language][57824].Text}:";
                             case EffectUnitTypeEnum.ConvertableCavalry:
                                 return
                                     languages["stringtablex"][language][38214].Text + " " + languages["stringtablex"][language][65459].Text;


### PR DESCRIPTION
Updated logic for Effect Traits

# Description
This Change updates the file EconTratExt.cs

Changes made are:
At line 59 i used a different switch Enum instead of the existing one.  I used ResourceTypeEnum and it comes from Resources.cs
Can you please confirm that this will work?

Other changes clearly separated the type of Unit Types that are affected and wrote the correct stringTablex for them.
At the very bottom, i have made a 

## Type of distinction between actions, additive modifiers and Regeneration and added added one more 1 to them. 

Please delete options that are not relevant.

- [Yes] Bug fix (non-breaking change which fixes an issue)
- [Yes ] New feature (non-breaking change which adds functionality)

## Checklist:

- [Yes ] My code follows the style guidelines of this project
- [ Yes] I have performed a self-review of my own code
- [ Yes] I have commented my code, particularly in hard-to-understand areas
- [Cannot Test ] My changes generate no new warnings