### PR TITLE
fix the quick issue with the text at the end of conservation but not dup stats

### DIFF
--- a/src/Extension/EconTraitExt.cs
+++ b/src/Extension/EconTraitExt.cs
@@ -264,40 +264,7 @@ namespace ProjectCeleste.GameFiles.XMLParser.Extension
                     }
                 case EffectSubTypeEnum.Yield:
                     {
-                        switch (effect.UnitType)
-                        {
-                            case EffectUnitTypeEnum.AbstractFruit:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.AbstractFarm:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.AbstractFish:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Fish:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Herdable:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Huntable:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Tree:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Gold:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            case EffectUnitTypeEnum.Stone:
-                                return
-                                    languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                            default:
-                                //Instead of throw excemption, I put a default text.
-                                return languages["stringtablex"][language][300046].Text.Replace(" +%1.1f", string.Empty) + ":";
-                                //throw new ArgumentOutOfRangeException(nameof(effect.UnitType), effect.UnitType, null);
-                        }
+                        return  languages["stringtablex"][language][300046].Text.Replace(" %s%.1f%%", string.Empty) + ":";
                     }
                     case EffectSubTypeEnum.HitPercentDamageMultiplier:
                     {


### PR DESCRIPTION
# Description


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings